### PR TITLE
Android/feat/bottomsheet

### DIFF
--- a/android/campung/.claude/settings.local.json
+++ b/android/campung/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(.gradlew build)",
       "Bash(gradlew.bat build:*)",
       "Bash(./gradlew:*)",
-      "Bash(adb logcat:*)"
+      "Bash(adb logcat:*)",
+      "Read(/C:\\Users\\SSAFY\\Downloads/**)"
     ],
     "deny": [],
     "ask": []

--- a/android/campung/.claude/settings.local.json
+++ b/android/campung/.claude/settings.local.json
@@ -5,7 +5,8 @@
       "Bash(gradlew.bat build:*)",
       "Bash(./gradlew:*)",
       "Bash(adb logcat:*)",
-      "Read(/C:\\Users\\SSAFY\\Downloads/**)"
+      "Read(/C:\\Users\\SSAFY\\Downloads/**)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/android/campung/app/build.gradle.kts
+++ b/android/campung/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true  // Java 8 time API 지원
     }
     
     kotlinOptions {
@@ -113,4 +114,9 @@ dependencies {
     implementation("com.naver.maps:map-sdk:3.22.1") // 네이버 지도 SDK
     implementation("com.google.android.gms:play-services-location:21.3.0") // 위치
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4") // Compose-Lifecycle
+    
+    // 바텀시트 추가 의존성
+    implementation("com.github.bumptech.glide:compose:1.0.0-beta01") // Glide for Compose
+    implementation("io.github.fornewid:naver-map-compose:1.7.0") // NaverMap Compose
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4") // Java 8 time API
 }

--- a/android/campung/app/src/main/java/com/shinhan/campung/MainActivity.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.shinhan.campung
 
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
@@ -40,6 +42,14 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        // 시스템 바 투명 처리 및 컨텐츠 확장
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
+        )
+        
         setContent {
             CampungTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {

--- a/android/campung/app/src/main/java/com/shinhan/campung/MainActivity.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.shinhan.campung
 
+import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -42,14 +43,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        
-        // 시스템 바 투명 처리 및 컨텐츠 확장
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
-            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS
-        )
-        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = true // 자동 대비 조정 비활성화
+        }
         setContent {
             CampungTheme {
                 Surface(color = MaterialTheme.colorScheme.background) {

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/mapper/ContentMapper.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/mapper/ContentMapper.kt
@@ -1,0 +1,40 @@
+package com.shinhan.campung.data.mapper
+
+import com.shinhan.campung.data.model.ContentData
+import com.shinhan.campung.data.model.ContentCategory
+import com.shinhan.campung.data.model.MapContent
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class ContentMapper @Inject constructor() {
+    
+    fun toMapContent(data: ContentData): MapContent {
+        return MapContent(
+            contentId = data.contentId,
+            title = data.title,
+            content = data.body,
+            authorNickname = if (data.author.anonymous) "익명" else data.author.nickname,
+            category = ContentCategory.fromValue(data.postType),
+            thumbnailUrl = data.mediaFiles.firstOrNull()?.thumbnailUrl,
+            latitude = data.location?.latitude ?: 0.0,
+            longitude = data.location?.longitude ?: 0.0,
+            likeCount = data.likeCount,
+            commentCount = data.commentCount,
+            createdAt = parseDateTime(data.createdAt),
+            isHot = data.hotContent
+        )
+    }
+    
+    private fun parseDateTime(dateStr: String?): LocalDateTime {
+        return try {
+            if (dateStr != null) {
+                LocalDateTime.parse(dateStr, DateTimeFormatter.ISO_DATE_TIME)
+            } else {
+                LocalDateTime.now()
+            }
+        } catch (e: Exception) {
+            LocalDateTime.now()
+        }
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/model/ContentResponse.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/model/ContentResponse.kt
@@ -1,0 +1,36 @@
+package com.shinhan.campung.data.model
+
+data class ContentResponse(
+    val success: Boolean,
+    val message: String,
+    val data: ContentData
+)
+
+data class ContentData(
+    val contentId: Long,
+    val userId: String,
+    val author: Author,
+    val location: Location?,
+    val postType: String,
+    val title: String,
+    val body: String,
+    val mediaFiles: List<MediaFile>,
+    val hotContent: Boolean,
+    val likeCount: Int = 0,
+    val commentCount: Int = 0,
+    val createdAt: String? = null // ISO 8601 format
+)
+
+data class Author(
+    val nickname: String,
+    val anonymous: Boolean
+)
+
+data class Location(
+    val latitude: Double,
+    val longitude: Double
+)
+
+data class MediaFile(
+    val thumbnailUrl: String
+)

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/model/MapContent.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/model/MapContent.kt
@@ -1,0 +1,33 @@
+package com.shinhan.campung.data.model
+
+import com.shinhan.campung.R
+import java.time.LocalDateTime
+
+data class MapContent(
+    val contentId: Long,
+    val title: String,
+    val content: String,
+    val authorNickname: String,
+    val category: ContentCategory,
+    val thumbnailUrl: String?,
+    val latitude: Double,
+    val longitude: Double,
+    val likeCount: Int = 0,
+    val commentCount: Int = 0,
+    val createdAt: LocalDateTime,
+    val isHot: Boolean = false
+)
+
+enum class ContentCategory(val value: String, val iconRes: Int, val displayName: String) {
+    INFO("info", R.drawable.ic_info, "정보"),
+    PROMOTION("promotion", R.drawable.ic_promotion, "홍보"),
+    FREE("free", R.drawable.ic_free, "자유"),
+    MARKET("market", R.drawable.ic_market, "장터"),
+    HOT("hot", R.drawable.ic_hot, "인기");
+    
+    companion object {
+        fun fromValue(value: String): ContentCategory {
+            return values().find { it.value == value } ?: FREE
+        }
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/MapApiService.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/MapApiService.kt
@@ -1,0 +1,10 @@
+package com.shinhan.campung.data.remote.api
+
+import com.shinhan.campung.data.model.ContentResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface MapApiService {
+    @GET("/api/contents/{contentId}")
+    suspend fun getContent(@Path("contentId") contentId: Long): ContentResponse
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/repository/MapContentRepository.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/repository/MapContentRepository.kt
@@ -1,0 +1,47 @@
+package com.shinhan.campung.data.repository
+
+import com.shinhan.campung.data.mapper.ContentMapper
+import com.shinhan.campung.data.model.MapContent
+import com.shinhan.campung.data.remote.api.MapApiService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+interface MapContentRepository {
+    suspend fun getContentById(contentId: Long): Result<MapContent>
+    suspend fun getContentsByIds(contentIds: List<Long>): Result<List<MapContent>>
+}
+
+@Singleton
+class MapContentRepositoryImpl @Inject constructor(
+    private val apiService: MapApiService,
+    private val mapper: ContentMapper
+) : MapContentRepository {
+    
+    override suspend fun getContentById(contentId: Long): Result<MapContent> = 
+        withContext(Dispatchers.IO) {
+            try {
+                val response = apiService.getContent(contentId)
+                if (response.success) {
+                    Result.success(mapper.toMapContent(response.data))
+                } else {
+                    Result.failure(Exception(response.message))
+                }
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+    
+    override suspend fun getContentsByIds(contentIds: List<Long>): Result<List<MapContent>> =
+        withContext(Dispatchers.IO) {
+            try {
+                val contents = contentIds.mapNotNull { id ->
+                    getContentById(id).getOrNull()
+                }
+                Result.success(contents)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
+        }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/repository/MockMapContentRepository.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/repository/MockMapContentRepository.kt
@@ -1,0 +1,123 @@
+package com.shinhan.campung.data.repository
+
+import com.shinhan.campung.data.model.ContentCategory
+import com.shinhan.campung.data.model.MapContent
+import kotlinx.coroutines.delay
+import java.time.LocalDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MockMapContentRepository @Inject constructor() : MapContentRepository {
+    
+    // 테스트용 샘플 데이터
+    private val sampleContents = mapOf(
+        1L to MapContent(
+            contentId = 1L,
+            title = "신한은행 본점 앞 이벤트",
+            content = "신한은행 본점에서 진행하는 특별 이벤트입니다. 많은 참여 부탁드립니다!",
+            authorNickname = "이벤트팀",
+            category = ContentCategory.PROMOTION,
+            thumbnailUrl = null,
+            latitude = 37.5665,
+            longitude = 126.9780,
+            likeCount = 12,
+            commentCount = 5,
+            createdAt = LocalDateTime.now().minusHours(2),
+            isHot = true
+        ),
+        2L to MapContent(
+            contentId = 2L,
+            title = "점심 맛집 추천",
+            content = "을지로 맛집 추천합니다. 가성비 좋고 맛있어요~",
+            authorNickname = "맛집탐방러",
+            category = ContentCategory.FREE,
+            thumbnailUrl = null,
+            latitude = 37.5665,
+            longitude = 126.9780,
+            likeCount = 8,
+            commentCount = 3,
+            createdAt = LocalDateTime.now().minusHours(1),
+            isHot = false
+        ),
+        3L to MapContent(
+            contentId = 3L,
+            title = "중고 노트북 판매",
+            content = "맥북 프로 16인치 판매합니다. 상태 양호하며 박스 포함입니다.",
+            authorNickname = "노트북판매자",
+            category = ContentCategory.MARKET,
+            thumbnailUrl = null,
+            latitude = 37.5640,
+            longitude = 126.9750,
+            likeCount = 15,
+            commentCount = 8,
+            createdAt = LocalDateTime.now().minusMinutes(30),
+            isHot = false
+        ),
+        4L to MapContent(
+            contentId = 4L,
+            title = "종로 맛집 정보",
+            content = "종로3가 근처 숨겨진 맛집을 소개합니다. 현지인만 아는 그 곳!",
+            authorNickname = "종로토박이",
+            category = ContentCategory.INFO,
+            thumbnailUrl = null,
+            latitude = 37.5660,
+            longitude = 126.9820,
+            likeCount = 25,
+            commentCount = 12,
+            createdAt = LocalDateTime.now().minusMinutes(15),
+            isHot = true
+        ),
+        5L to MapContent(
+            contentId = 5L,
+            title = "카페 알바 구합니다",
+            content = "종로 카페에서 파트타임 직원을 구합니다. 시급 협의 가능합니다.",
+            authorNickname = "카페사장",
+            category = ContentCategory.INFO,
+            thumbnailUrl = null,
+            latitude = 37.5660,
+            longitude = 126.9820,
+            likeCount = 6,
+            commentCount = 2,
+            createdAt = LocalDateTime.now().minusMinutes(45),
+            isHot = false
+        ),
+        6L to MapContent(
+            contentId = 6L,
+            title = "스터디 모집",
+            content = "토익 스터디원을 모집합니다. 주 3회 만나서 공부해요~",
+            authorNickname = "스터디장",
+            category = ContentCategory.FREE,
+            thumbnailUrl = null,
+            latitude = 37.5660,
+            longitude = 126.9820,
+            likeCount = 9,
+            commentCount = 4,
+            createdAt = LocalDateTime.now().minusHours(3),
+            isHot = false
+        )
+    )
+    
+    override suspend fun getContentById(contentId: Long): Result<MapContent> {
+        // API 호출 시뮬레이션을 위한 딜레이
+        delay(500)
+        
+        return sampleContents[contentId]?.let {
+            Result.success(it)
+        } ?: Result.failure(Exception("Content not found: $contentId"))
+    }
+    
+    override suspend fun getContentsByIds(contentIds: List<Long>): Result<List<MapContent>> {
+        // API 호출 시뮬레이션을 위한 딜레이
+        delay(800)
+        
+        return try {
+            val contents = contentIds.mapNotNull { id ->
+                sampleContents[id]
+            }
+            Result.success(contents)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/di/MapModule.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/di/MapModule.kt
@@ -1,0 +1,41 @@
+package com.shinhan.campung.di
+
+import com.shinhan.campung.data.remote.api.MapApiService
+import com.shinhan.campung.data.repository.MapContentRepository
+import com.shinhan.campung.data.repository.MapContentRepositoryImpl
+import com.shinhan.campung.data.repository.MockMapContentRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class MapModule {
+    
+    // 실제 API 사용시
+    // @Binds
+    // abstract fun bindMapContentRepository(
+    //     mapContentRepositoryImpl: MapContentRepositoryImpl
+    // ): MapContentRepository
+    
+    // 테스트용 Mock Repository 사용
+    @Binds
+    abstract fun bindMapContentRepository(
+        mockMapContentRepository: MockMapContentRepository
+    ): MapContentRepository
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object MapApiModule {
+    
+    @Provides
+    @Singleton
+    fun provideMapApiService(retrofit: Retrofit): MapApiService {
+        return retrofit.create(MapApiService::class.java)
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapBottomSheetContent.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapBottomSheetContent.kt
@@ -12,31 +12,39 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.material3.Surface
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.shinhan.campung.data.model.MapContent
-
 @Composable
 fun MapBottomSheetContent(
     contents: List<MapContent>,
+    isLoading: Boolean = false,
     isInteractionEnabled: Boolean = true,
+    navigationBarHeight: Dp = 0.dp, // 추가된 파라미터
+    statusBarHeight: Dp = 0.dp, // 추가된 파라미터
     onContentClick: (MapContent) -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenHeight = configuration.screenHeightDp.dp
-    
+
     // 높이 구성 요소
     val itemHeight = 120.dp
     val padding = 16.dp
     val itemSpacing = 8.dp
-    
-    // 동적 높이 계산 (확장시)
+
+    // 네비게이션 바와 상태바를 모두 제외한 사용 가능한 높이
+    val availableHeight = screenHeight - navigationBarHeight - statusBarHeight
+
     val expandedHeight = when (contents.size) {
-        0 -> 0.dp  // 빈 상태: 기본 핸들만 보임 (BottomSheetScaffold에서 처리)
+        0 -> 0.dp
         1 -> itemHeight + (padding * 2)
         2 -> (itemHeight * 2) + itemSpacing + (padding * 2)
-        else -> screenHeight * 0.5f  // 3개 이상은 화면 절반
+        else -> availableHeight * 0.5f  // 실제 사용가능 높이의 50%
     }
-    
+
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -48,7 +56,27 @@ fun MapBottomSheetContent(
             modifier = Modifier.fillMaxWidth()
         ) {
         // 컨텐츠 리스트
-        if (contents.isEmpty()) {
+        if (isLoading) {
+            // 로딩 상태: 즉각적인 피드백 제공
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(120.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    CircularProgressIndicator(color = Color(0xFF0066FF))
+                    Text(
+                        text = "콘텐츠를 불러오는 중...",
+                        fontSize = 14.sp,
+                        color = Color.Gray
+                    )
+                }
+            }
+        } else if (contents.isEmpty()) {
             // 빈 상태: 핸들만 보이고 상호작용 불가
             Box(
                 modifier = Modifier

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapBottomSheetContent.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapBottomSheetContent.kt
@@ -1,0 +1,80 @@
+package com.shinhan.campung.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.material3.Surface
+import androidx.compose.ui.unit.dp
+import com.shinhan.campung.data.model.MapContent
+
+@Composable
+fun MapBottomSheetContent(
+    contents: List<MapContent>,
+    isInteractionEnabled: Boolean = true,
+    onContentClick: (MapContent) -> Unit = {}
+) {
+    val configuration = LocalConfiguration.current
+    val screenHeight = configuration.screenHeightDp.dp
+    
+    // 높이 구성 요소
+    val itemHeight = 120.dp
+    val padding = 16.dp
+    val itemSpacing = 8.dp
+    
+    // 동적 높이 계산 (확장시)
+    val expandedHeight = when (contents.size) {
+        0 -> 0.dp  // 빈 상태: 기본 핸들만 보임 (BottomSheetScaffold에서 처리)
+        1 -> itemHeight + (padding * 2)
+        2 -> (itemHeight * 2) + itemSpacing + (padding * 2)
+        else -> screenHeight * 0.5f  // 3개 이상은 화면 절반
+    }
+    
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = expandedHeight),  // 최대 높이 제한
+        color = Color.White,  // 강제로 흰색 배경
+        contentColor = Color.Black  // 텍스트 색상 검은색
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+        // 컨텐츠 리스트
+        if (contents.isEmpty()) {
+            // 빈 상태: 핸들만 보이고 상호작용 불가
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                // 빈 상태 표시 (선택사항)
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentPadding = PaddingValues(padding),
+                verticalArrangement = Arrangement.spacedBy(itemSpacing)
+            ) {
+                items(contents) { content ->
+                    MapContentItem(
+                        content = content,
+                        modifier = Modifier.height(itemHeight),
+                        onClick = { if (isInteractionEnabled) onContentClick(content) }
+                    )
+                }
+            }
+        }
+        }
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapContentItem.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapContentItem.kt
@@ -39,11 +39,11 @@ fun MapContentItem(
     ) {
         Row(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                .fillMaxSize(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            // 이미지
+            // 이미지 - 정사각형
             Box(
                 modifier = Modifier
                     .size(96.dp)
@@ -64,14 +64,15 @@ fun MapContentItem(
             Column(
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxHeight(),
-                verticalArrangement = Arrangement.SpaceBetween
+                    .fillMaxHeight()
+                    .padding(vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 // 제목과 카테고리
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.Top
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
                         text = content.title,
@@ -79,7 +80,9 @@ fun MapContentItem(
                         fontSize = 16.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 8.dp)
                     )
                     
                     Icon(
@@ -97,28 +100,40 @@ fun MapContentItem(
                     color = Color.Gray,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.padding(vertical = 4.dp)
+                    lineHeight = 18.sp
                 )
+                // Spacer로 하단에 메타정보 고정
+                Spacer(modifier = Modifier.weight(1f))
                 
-                // 작성자 정보와 시간
-                Text(
-                    text = "${content.authorNickname} · ${TimeFormatter.formatRelativeTime(content.createdAt)}",
-                    fontSize = 12.sp,
-                    color = Color.Gray
-                )
-                
-                // 좋아요, 댓글
+                // 작성자 정보와 좋아요/댓글
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
+                    // 작성자 정보와 시간
+                    Text(
+                        text = "${content.authorNickname} · ${TimeFormatter.formatRelativeTime(content.createdAt)}",
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                    
+                    // 좋아요, 댓글
                     Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_heart),
-                            contentDescription = "좋아요",
-                            modifier = Modifier.size(16.dp),
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_heart),
+                                contentDescription = "좋아요",
+                                modifier = Modifier.size(16.dp),
                             tint = Color.Gray
                         )
                         Text(
@@ -126,23 +141,24 @@ fun MapContentItem(
                             fontSize = 12.sp,
                             color = Color.Gray
                         )
-                    }
-                    
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Icon(
-                            painter = painterResource(id = R.drawable.ic_comment),
-                            contentDescription = "댓글",
-                            modifier = Modifier.size(16.dp),
-                            tint = Color.Gray
-                        )
-                        Text(
-                            text = content.commentCount.toString(),
-                            fontSize = 12.sp,
-                            color = Color.Gray
-                        )
+                        }
+                        
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_comment),
+                                contentDescription = "댓글",
+                                modifier = Modifier.size(16.dp),
+                                tint = Color.Gray
+                            )
+                            Text(
+                                text = content.commentCount.toString(),
+                                fontSize = 12.sp,
+                                color = Color.Gray
+                            )
+                        }
                     }
                 }
             }

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapContentItem.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/MapContentItem.kt
@@ -1,0 +1,162 @@
+package com.shinhan.campung.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+import com.shinhan.campung.R
+import com.shinhan.campung.data.model.ContentCategory
+import com.shinhan.campung.data.model.MapContent
+import com.shinhan.campung.presentation.utils.TimeFormatter
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@Composable
+fun MapContentItem(
+    content: MapContent,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(120.dp),
+        onClick = onClick,
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // 이미지
+            Box(
+                modifier = Modifier
+                    .size(96.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.LightGray)
+            ) {
+                content.thumbnailUrl?.let { url ->
+                    GlideImage(
+                        model = url,
+                        contentDescription = null,
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+            }
+            
+            // 컨텐츠 정보
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                // 제목과 카테고리
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.Top
+                ) {
+                    Text(
+                        text = content.title,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 16.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    
+                    Icon(
+                        painter = painterResource(id = content.category.iconRes),
+                        contentDescription = content.category.displayName,
+                        modifier = Modifier.size(20.dp),
+                        tint = getCategoryColor(content.category)
+                    )
+                }
+                
+                // 본문 내용
+                Text(
+                    text = content.content,
+                    fontSize = 14.sp,
+                    color = Color.Gray,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+                
+                // 작성자 정보와 시간
+                Text(
+                    text = "${content.authorNickname} · ${TimeFormatter.formatRelativeTime(content.createdAt)}",
+                    fontSize = 12.sp,
+                    color = Color.Gray
+                )
+                
+                // 좋아요, 댓글
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_heart),
+                            contentDescription = "좋아요",
+                            modifier = Modifier.size(16.dp),
+                            tint = Color.Gray
+                        )
+                        Text(
+                            text = content.likeCount.toString(),
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                    }
+                    
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_comment),
+                            contentDescription = "댓글",
+                            modifier = Modifier.size(16.dp),
+                            tint = Color.Gray
+                        )
+                        Text(
+                            text = content.commentCount.toString(),
+                            fontSize = 12.sp,
+                            color = Color.Gray
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun getCategoryColor(category: ContentCategory): Color {
+    return when (category) {
+        ContentCategory.INFO -> Color(0xFF2196F3)
+        ContentCategory.PROMOTION -> Color(0xFFFF9800)
+        ContentCategory.FREE -> Color(0xFF4CAF50)
+        ContentCategory.MARKET -> Color(0xFF9C27B0)
+        ContentCategory.HOT -> Color(0xFFF44336)
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
@@ -11,20 +11,25 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Surface
+import androidx.compose.material3.*
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.core.content.ContextCompat
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -36,14 +41,53 @@ import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
+import com.naver.maps.map.overlay.Marker
+import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.widget.LocationButtonView
+import com.shinhan.campung.presentation.ui.components.MapBottomSheetContent
+import com.shinhan.campung.presentation.viewmodel.MapViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun FullMapScreen(
-    navController: NavController
+    navController: NavController,
+    mapViewModel: MapViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current.lifecycle
+    val configuration = LocalConfiguration.current
+    
+    // ViewModel states
+    val bottomSheetContents by mapViewModel.bottomSheetContents.collectAsState()
+    val isBottomSheetExpanded by mapViewModel.isBottomSheetExpanded.collectAsState()
+    
+    // BottomSheetScaffold state  
+    val scaffoldState = rememberBottomSheetScaffoldState(
+        bottomSheetState = rememberStandardBottomSheetState(
+            initialValue = SheetValue.PartiallyExpanded,
+            confirmValueChange = { targetValue ->
+                // 빈 상태에서는 확장을 허용하지 않음
+                if (bottomSheetContents.isEmpty()) {
+                    targetValue == SheetValue.PartiallyExpanded
+                } else {
+                    true
+                }
+            }
+        )
+    )
+    val screenHeight = configuration.screenHeightDp.dp
+    
+    // 높이 구성 요소 (기본 핸들은 BottomSheetScaffold에서 자동 처리)
+    val itemHeight = 120.dp
+    val padding = 16.dp
+    val itemSpacing = 8.dp
+    
+    // Peek 높이 (네비게이션 바 위에 핸들이 보이도록)
+    val density = LocalDensity.current
+    val navigationBarHeight = with(density) {
+        WindowInsets.navigationBars.getBottom(density).toDp()
+    }
+    val peekHeight = 24.dp + navigationBarHeight  // 기본 핸들 + 네비게이션 바 높이
 
     val mapView = remember { MapView(context).apply { onCreate(Bundle()) } }
     DisposableEffect(lifecycle, mapView) {
@@ -129,13 +173,42 @@ fun FullMapScreen(
 
     // 하드웨어/소프트웨어 뒤로가기 모두 홈으로
     BackHandler { navController.popBackStack() }
+    
+    // 마커 클릭시 자동 확장 제어
+    LaunchedEffect(bottomSheetContents.size) {
+        when (bottomSheetContents.size) {
+            0 -> {
+                // 빈 상태: 핸들만 보이고 드래그 불가
+                scaffoldState.bottomSheetState.partialExpand()
+            }
+            1 -> scaffoldState.bottomSheetState.expand()  // 1개: 1개 보이게 확장
+            2 -> scaffoldState.bottomSheetState.expand()  // 2개: 2개 다 보이게
+            else -> scaffoldState.bottomSheetState.expand()  // 3개+: 50% 최대 상태
+        }
+    }
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = Color.White
-    ) {
-        Box(Modifier.fillMaxSize()) {
-
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        sheetPeekHeight = peekHeight,
+        sheetContainerColor = Color.White,  // 바텀시트 배경색을 흰색으로
+        sheetContentColor = Color.Black,    // 바텀시트 텍스트 색상을 검은색으로
+        sheetContent = {
+            MapBottomSheetContent(
+                contents = bottomSheetContents,
+                isInteractionEnabled = bottomSheetContents.isNotEmpty(),
+                onContentClick = { content ->
+                    // TODO: 컨텐츠 상세 화면으로 이동
+                    // navController.navigate("content_detail/${content.contentId}")
+                }
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                // 시스템 바 영역을 피하도록 패딩 적용
+                .windowInsetsPadding(WindowInsets.systemBars)
+        ) {
             // 네이버 지도
             AndroidView(
                 factory = { mapView },
@@ -153,6 +226,14 @@ fun FullMapScreen(
                                 isCompassEnabled = true
                                 isLocationButtonEnabled = false // 자체 LocationButtonView 사용
                             }
+                            
+                            // 지도 이동시 바텀시트 축소
+                            map.addOnCameraChangeListener { _, _ ->
+                                mapViewModel.onMapMove()
+                            }
+                            
+                            // 예시 마커 추가 (실제 데이터는 WebSocket에서 받아올 예정)
+                            addSampleMarkers(map, mapViewModel)
                         }
                     } else {
                         naverMapRef?.let { map ->
@@ -175,7 +256,7 @@ fun FullMapScreen(
                     .padding(12.dp)
                     .align(Alignment.TopStart)
             ) {
-                Icon(Icons.Filled.ArrowBack, contentDescription = "뒤로가기")
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "뒤로가기")
             }
 
             Box(
@@ -222,6 +303,31 @@ fun FullMapScreen(
                         }
                 )
             }
+        }
+    }
+}
+
+// 예시 마커 추가 함수 (임시)
+private fun addSampleMarkers(map: NaverMap, mapViewModel: MapViewModel) {
+    // 테스트용 마커들
+    val sampleMarkers = listOf(
+        Triple(37.5665, 126.9780, listOf(1L, 2L)), // 서울시청 근처
+        Triple(37.5640, 126.9750, listOf(3L)), // 을지로 근처
+        Triple(37.5660, 126.9820, listOf(4L, 5L, 6L)) // 종로 근처
+    )
+    
+    sampleMarkers.forEachIndexed { index, (lat, lng, contentIds) ->
+        val marker = Marker()
+        marker.position = LatLng(lat, lng)
+        marker.map = map
+        marker.captionText = "마커 ${index + 1}"
+        
+        marker.setOnClickListener {
+            mapViewModel.onMarkerClick(
+                contentId = contentIds.first(),
+                associatedContentIds = contentIds
+            )
+            true
         }
     }
 }

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -12,7 +13,6 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material3.*
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.runtime.*
@@ -24,10 +24,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -42,12 +40,33 @@ import com.naver.maps.map.CameraUpdate
 import com.naver.maps.map.MapView
 import com.naver.maps.map.NaverMap
 import com.naver.maps.map.overlay.Marker
-import com.naver.maps.map.overlay.OverlayImage
 import com.naver.maps.map.widget.LocationButtonView
 import com.shinhan.campung.presentation.ui.components.MapBottomSheetContent
 import com.shinhan.campung.presentation.viewmodel.MapViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
+// 커스텀 bottom sheet를 위한 imports
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.saveable.rememberSaveable
+import kotlinx.coroutines.launch
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.zIndex
+import kotlin.math.abs
+
+// 커스텀 바텀시트 상태
+enum class CustomSheetValue {
+    PartiallyExpanded,
+    Expanded,
+    Hidden
+}
+
 @Composable
 fun FullMapScreen(
     navController: NavController,
@@ -56,39 +75,169 @@ fun FullMapScreen(
     val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val configuration = LocalConfiguration.current
-    
+    val density = LocalDensity.current
+    val coroutineScope = rememberCoroutineScope()
+
     // ViewModel states
     val bottomSheetContents by mapViewModel.bottomSheetContents.collectAsState()
     val isBottomSheetExpanded by mapViewModel.isBottomSheetExpanded.collectAsState()
-    
-    // BottomSheetScaffold state  
-    val scaffoldState = rememberBottomSheetScaffoldState(
-        bottomSheetState = rememberStandardBottomSheetState(
-            initialValue = SheetValue.PartiallyExpanded,
-            confirmValueChange = { targetValue ->
-                // 빈 상태에서는 확장을 허용하지 않음
-                if (bottomSheetContents.isEmpty()) {
-                    targetValue == SheetValue.PartiallyExpanded
-                } else {
-                    true
-                }
-            }
-        )
-    )
+    val isLoading by mapViewModel.isLoading.collectAsState()
+
+    // 화면 크기
     val screenHeight = configuration.screenHeightDp.dp
-    
-    // 높이 구성 요소 (기본 핸들은 BottomSheetScaffold에서 자동 처리)
     val itemHeight = 120.dp
     val padding = 16.dp
     val itemSpacing = 8.dp
-    
-    // Peek 높이 (네비게이션 바 위에 핸들이 보이도록)
-    val density = LocalDensity.current
-    val navigationBarHeight = with(density) {
-        WindowInsets.navigationBars.getBottom(density).toDp()
-    }
-    val peekHeight = 24.dp + navigationBarHeight  // 기본 핸들 + 네비게이션 바 높이
+    val dragHandleHeight = 30.dp // 드래그 핸들 영역 높이 30dp로 변경
+    val sheetHeaderHeight = 48.dp // 기본 시트 헤더 높이
 
+    // MapBottomSheetContent의 실제 패딩들 (추정값이 아닌 실제 컴포넌트 기준)
+    val bottomSheetContentPadding = 16.dp // MapBottomSheetContent 내부 패딩
+    val bottomSheetItemSpacing = 8.dp // 아이템 간 간격
+
+    // 커스텀 바텀시트 상태
+    var currentSheetValue by rememberSaveable { mutableStateOf(CustomSheetValue.PartiallyExpanded) }
+    var isDragging by remember { mutableStateOf(false) }
+
+    // Y 위치 계산
+    val screenHeightPx = with(density) { screenHeight.toPx() }
+    val navigationBarHeight = WindowInsets.navigationBars.getBottom(density)
+    val statusBarHeight = WindowInsets.statusBars.getTop(density) // 상태바 높이 추가
+    val availableHeightPx = screenHeightPx - navigationBarHeight - statusBarHeight // 상태바와 네비게이션 바 모두 제외
+
+    // 디버깅용 로그
+    LaunchedEffect(Unit) {
+        val navBarHeightDp = with(density) { navigationBarHeight.toDp() }
+        val statusBarHeightDp = with(density) { statusBarHeight.toDp() }
+        val availableHeightDp = with(density) { availableHeightPx.toDp() }
+        Log.d("BottomSheet", "=== 바텀시트 높이 디버깅 ===")
+        Log.d("BottomSheet", "Screen height: ${screenHeight}")
+        Log.d("BottomSheet", "Status bar height: ${statusBarHeightDp}")
+        Log.d("BottomSheet", "Navigation bar height: ${navBarHeightDp}")
+        Log.d("BottomSheet", "Available height: ${availableHeightDp}")
+        Log.d("BottomSheet", "Drag handle height: ${dragHandleHeight}")
+    }
+
+    // 바텀시트 위치 계산 - 로딩 상태 고려 및 정확한 패딩 계산
+    val sheetPositions = remember(availableHeightPx, density, bottomSheetContents.size, isLoading) {
+        object {
+            // 네비게이션 바 위에 드래그 핸들 + 더 큰 여유 공간 노출
+            val partiallyExpanded = availableHeightPx - with(density) {
+                (dragHandleHeight).toPx() // 네비게이션 바 위에 30dp 여유 공간 (기존 8dp에서 증가)
+            }
+
+            val contentHeight = when {
+                // 로딩 중일 때는 항상 1개 컨텐츠 크기로 계산 (모든 패딩 포함)
+                isLoading -> dragHandleHeight +
+                        bottomSheetContentPadding * 2 + // 상하 패딩
+                        itemHeight + // 로딩 영역 높이
+                        sheetHeaderHeight
+                // 로딩 완료 후 실제 컨텐츠 갯수에 따라 계산
+                bottomSheetContents.isEmpty() -> dragHandleHeight + sheetHeaderHeight
+                bottomSheetContents.size == 1 -> dragHandleHeight +
+                        itemHeight +
+                        sheetHeaderHeight
+                bottomSheetContents.size == 2 -> dragHandleHeight +
+                        (itemHeight * 2) +
+                        bottomSheetItemSpacing +
+                        sheetHeaderHeight
+                else -> {
+                    val maxHeight = screenHeight * 0.5f // 원래대로 되돌림
+                    val calculatedHeight = dragHandleHeight +
+                            bottomSheetContentPadding * 2 +
+                            (itemHeight * bottomSheetContents.size) +
+                            (bottomSheetItemSpacing * (bottomSheetContents.size - 1)) +
+                            sheetHeaderHeight
+                    minOf(maxHeight, calculatedHeight)
+                }
+            }
+            val calculatedExpanded = availableHeightPx - with(density) { contentHeight.toPx() } // screenHeightPx 대신 availableHeightPx 사용
+            // 안전장치: expanded가 partiallyExpanded보다 작아야 함 (Y좌표계에서 위쪽이 작은 값)
+            val expanded = calculatedExpanded.coerceAtMost(partiallyExpanded - with(density) { 10.dp.toPx() })
+        }
+    }
+
+    // 바텀시트 위치 디버깅 로그 (remember 블록 밖에서)
+    LaunchedEffect(sheetPositions, bottomSheetContents.size, isLoading) {
+        Log.d("BottomSheet", "=== 바텀시트 위치 계산 ===")
+        Log.d("BottomSheet", "PartiallyExpanded: ${with(density) { sheetPositions.partiallyExpanded.toDp() }}")
+        Log.d("BottomSheet", "Expanded: ${with(density) { sheetPositions.expanded.toDp() }}")
+        Log.d("BottomSheet", "Contents size: ${bottomSheetContents.size}, isLoading: $isLoading")
+    }
+
+    // Animatable for smooth animation
+    val sheetAnimY = remember { Animatable(sheetPositions.partiallyExpanded) }
+
+    // 상태 변경시 애니메이션
+    LaunchedEffect(currentSheetValue) {
+        val targetY = when (currentSheetValue) {
+            CustomSheetValue.PartiallyExpanded -> sheetPositions.partiallyExpanded
+            CustomSheetValue.Expanded -> sheetPositions.expanded
+            CustomSheetValue.Hidden -> screenHeightPx
+        }
+
+        sheetAnimY.animateTo(
+            targetValue = targetY,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessLow
+            )
+        )
+    }
+
+    // sheetPositions가 변경될 때도 애니메이션 재실행 (로딩 완료 후 크기 조정)
+    LaunchedEffect(sheetPositions) {
+        val targetY = when (currentSheetValue) {
+            CustomSheetValue.PartiallyExpanded -> sheetPositions.partiallyExpanded
+            CustomSheetValue.Expanded -> sheetPositions.expanded
+            CustomSheetValue.Hidden -> screenHeightPx
+        }
+
+        sheetAnimY.animateTo(
+            targetValue = targetY,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessLow
+            )
+        )
+    }
+
+    // LocationButton 오프셋 계산
+    val locationButtonOffsetY = with(density) {
+        val currentOffset = (sheetAnimY.value - sheetPositions.partiallyExpanded).coerceAtMost(0f)
+        currentOffset.toDp()
+    }
+
+    // 빈 상태에서는 확장을 허용하지 않음 (단, 로딩 중에는 허용)
+    fun confirmValueChange(targetValue: CustomSheetValue): Boolean {
+        return if (bottomSheetContents.isEmpty() && !isLoading) {
+            targetValue == CustomSheetValue.PartiallyExpanded
+        } else {
+            true
+        }
+    }
+
+    // 드래그 처리
+    fun handleDragEnd(velocity: Float, currentPosition: Float) {
+        val fastSwipeThreshold = 800f
+        val midpoint = (sheetPositions.partiallyExpanded + sheetPositions.expanded) / 2
+
+        val targetState = when {
+            // 로딩 중이 아니고 컨텐츠가 없으면 축소 상태만 허용
+            bottomSheetContents.isEmpty() && !isLoading -> CustomSheetValue.PartiallyExpanded
+            velocity > fastSwipeThreshold -> CustomSheetValue.PartiallyExpanded
+            velocity < -fastSwipeThreshold -> CustomSheetValue.Expanded
+            currentPosition > midpoint -> CustomSheetValue.PartiallyExpanded
+            else -> CustomSheetValue.Expanded
+        }
+
+        if (confirmValueChange(targetState)) {
+            currentSheetValue = targetState
+        }
+        isDragging = false
+    }
+
+    // 지도 설정
     val mapView = remember { MapView(context).apply { onCreate(Bundle()) } }
     DisposableEffect(lifecycle, mapView) {
         val observer = object : DefaultLifecycleObserver {
@@ -102,6 +251,7 @@ fun FullMapScreen(
         onDispose { lifecycle.removeObserver(observer) }
     }
 
+    // 위치 권한 및 관련 로직
     fun hasLocationPermission(): Boolean {
         val fine = ContextCompat.checkSelfPermission(
             context, Manifest.permission.ACCESS_FINE_LOCATION
@@ -120,7 +270,6 @@ fun FullMapScreen(
     @SuppressLint("MissingPermission")
     fun fetchMyLocationOnce() {
         if (!hasLocationPermission()) return
-        // last + current
         fused.lastLocation.addOnSuccessListener { loc ->
             if (loc != null && myLatLng == null) {
                 myLatLng = LatLng(loc.latitude, loc.longitude)
@@ -171,45 +320,44 @@ fun FullMapScreen(
         }
     }
 
-    // 하드웨어/소프트웨어 뒤로가기 모두 홈으로
     BackHandler { navController.popBackStack() }
-    
-    // 마커 클릭시 자동 확장 제어
-    LaunchedEffect(bottomSheetContents.size) {
-        when (bottomSheetContents.size) {
-            0 -> {
-                // 빈 상태: 핸들만 보이고 드래그 불가
-                scaffoldState.bottomSheetState.partialExpand()
-            }
-            1 -> scaffoldState.bottomSheetState.expand()  // 1개: 1개 보이게 확장
-            2 -> scaffoldState.bottomSheetState.expand()  // 2개: 2개 다 보이게
-            else -> scaffoldState.bottomSheetState.expand()  // 3개+: 50% 최대 상태
+
+    // 마커 클릭시 자동 확장 - 로딩 상태와 컨텐츠 갯수 모두 고려
+    LaunchedEffect(isLoading) {
+        // 로딩 시작시 바로 확장
+        if (isLoading) {
+            currentSheetValue = CustomSheetValue.Expanded
         }
     }
 
-    BottomSheetScaffold(
-        scaffoldState = scaffoldState,
-        sheetPeekHeight = peekHeight,
-        sheetContainerColor = Color.White,  // 바텀시트 배경색을 흰색으로
-        sheetContentColor = Color.Black,    // 바텀시트 텍스트 색상을 검은색으로
-        sheetContent = {
-            MapBottomSheetContent(
-                contents = bottomSheetContents,
-                isInteractionEnabled = bottomSheetContents.isNotEmpty(),
-                onContentClick = { content ->
-                    // TODO: 컨텐츠 상세 화면으로 이동
-                    // navController.navigate("content_detail/${content.contentId}")
-                }
-            )
+    LaunchedEffect(bottomSheetContents.size) {
+        // 로딩이 끝나고 컨텐츠가 업데이트될 때
+        if (!isLoading) {
+            when {
+                bottomSheetContents.isEmpty() -> currentSheetValue = CustomSheetValue.PartiallyExpanded
+                bottomSheetContents.size >= 1 -> currentSheetValue = CustomSheetValue.Expanded
+            }
         }
-    ) { paddingValues ->
+    }
+
+    // isBottomSheetExpanded와 동기화
+    LaunchedEffect(isBottomSheetExpanded) {
+        if (isBottomSheetExpanded && (bottomSheetContents.isNotEmpty() || isLoading)) {
+            currentSheetValue = CustomSheetValue.Expanded
+        } else if (!isBottomSheetExpanded && bottomSheetContents.isNotEmpty() && !isLoading) {
+            currentSheetValue = CustomSheetValue.PartiallyExpanded
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier.navigationBarsPadding()
+    ) { innerPadding ->
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                // 시스템 바 영역을 피하도록 패딩 적용
-                .windowInsetsPadding(WindowInsets.systemBars)
+                .padding(innerPadding)
         ) {
-            // 네이버 지도
+            // 전체 화면 지도
             AndroidView(
                 factory = { mapView },
                 update = { mv ->
@@ -224,15 +372,14 @@ fun FullMapScreen(
                                 isZoomControlEnabled = false
                                 isScaleBarEnabled = false
                                 isCompassEnabled = true
-                                isLocationButtonEnabled = false // 자체 LocationButtonView 사용
+                                isLocationButtonEnabled = false
                             }
-                            
+
                             // 지도 이동시 바텀시트 축소
                             map.addOnCameraChangeListener { _, _ ->
                                 mapViewModel.onMapMove()
                             }
-                            
-                            // 예시 마커 추가 (실제 데이터는 WebSocket에서 받아올 예정)
+
                             addSampleMarkers(map, mapViewModel)
                         }
                     } else {
@@ -249,7 +396,7 @@ fun FullMapScreen(
                 modifier = Modifier.fillMaxSize()
             )
 
-            // 상단 좌측: 뒤로가기(아이콘)
+            // 뒤로가기 버튼
             IconButton(
                 onClick = { navController.popBackStack() },
                 modifier = Modifier
@@ -259,21 +406,24 @@ fun FullMapScreen(
                 Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "뒤로가기")
             }
 
+            // LocationButton - 바텀시트와 함께 움직임
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .padding(16.dp)
+                    .padding(
+                        start = 16.dp,
+                        bottom = 16.dp + dragHandleHeight // 바텀시트 드래그 핸들 높이(30dp)만큼 위로
+                    )
+                    .offset(y = locationButtonOffsetY)
             ) {
                 AndroidView(
                     factory = { ctx -> LocationButtonView(ctx) },
                     update = { btn ->
-                        // 모양/애니메이션은 유지하고, 실제 기능은 오버레이에서 처리
                         naverMapRef?.let { btn.map = it }
                     }
-                    // size는 기본 wrapContent. 필요시 .size(48.dp) 등 지정 가능
                 )
 
-                // 클릭 오버레이 (FAB 기능 통합)
+                // 클릭 오버레이
                 Box(
                     modifier = Modifier
                         .matchParentSize()
@@ -303,25 +453,121 @@ fun FullMapScreen(
                         }
                 )
             }
+
+            // 커스텀 바텀시트 - 배경을 사용가능한 높이까지만 연장 (상단만 radius)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(with(density) { availableHeightPx.toDp() }) // screenHeightPx 대신 availableHeightPx 사용
+                    .offset(y = with(density) { sheetAnimY.value.toDp() })
+                    .background(
+                        color = Color.White,
+                        shape = RoundedCornerShape(
+                            topStart = 16.dp,
+                            topEnd = 16.dp,
+                            bottomStart = 0.dp,
+                            bottomEnd = 0.dp
+                        ) // 상단만 radius, 하단은 직각
+                    )
+            ) {
+                // 실제 바텀시트 컨텐츠
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(
+                            elevation = 8.dp,
+                            shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+                            spotColor = Color.Black.copy(alpha = 0.1f)
+                        )
+                        .background(
+                            color = Color.White,
+                            shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
+                        )
+                ) {
+                    Column {
+                        // 드래그 핸들 - 더 큰 터치 영역으로 확장
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(dragHandleHeight) // 터치 영역 확장
+                                .pointerInput(Unit) {
+                                    var totalDragAmount = 0f
+                                    var dragStartTime = 0L
+
+                                    detectDragGestures(
+                                        onDragStart = {
+                                            isDragging = true
+                                            totalDragAmount = 0f
+                                            dragStartTime = System.currentTimeMillis()
+                                        },
+                                        onDragEnd = {
+                                            val duration = System.currentTimeMillis() - dragStartTime
+                                            val velocity =
+                                                if (duration > 0) totalDragAmount / duration * 1000 else 0f
+                                            handleDragEnd(velocity, sheetAnimY.value)
+                                        }
+                                    ) { _, dragAmount ->
+                                        totalDragAmount += dragAmount.y
+
+                                        // 드래그 중 실시간 업데이트
+                                        coroutineScope.launch {
+                                            val newY = (sheetAnimY.value + dragAmount.y).coerceIn(
+                                                sheetPositions.expanded, // min (위쪽, 작은 값)
+                                                sheetPositions.partiallyExpanded // max (아래쪽, 큰 값)
+                                            )
+                                            sheetAnimY.snapTo(newY)
+                                        }
+                                    }
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            // 드래그 핸들 UI
+                            Box(
+                                modifier = Modifier
+                                    .width(40.dp)
+                                    .height(4.dp)
+                                    .background(
+                                        color = Color.Gray,
+                                        shape = RoundedCornerShape(2.dp)
+                                    )
+                                    .semantics {
+                                        contentDescription = "바텀시트 드래그 핸들"
+                                    }
+                            )
+                        }
+
+                        // 바텀시트 콘텐츠
+                        MapBottomSheetContent(
+                            contents = bottomSheetContents,
+                            isLoading = isLoading,
+                            isInteractionEnabled = bottomSheetContents.isNotEmpty() || isLoading,
+                            navigationBarHeight = with(density) { navigationBarHeight.toDp() },
+                            statusBarHeight = with(density) { statusBarHeight.toDp() }, // 상태바 높이도 전달
+                            onContentClick = { content ->
+                                // TODO: 컨텐츠 상세 화면으로 이동
+                            }
+                        )
+                    }
+                }
+            }
         }
     }
 }
 
-// 예시 마커 추가 함수 (임시)
+// 예시 마커 추가 함수
 private fun addSampleMarkers(map: NaverMap, mapViewModel: MapViewModel) {
-    // 테스트용 마커들
     val sampleMarkers = listOf(
-        Triple(37.5665, 126.9780, listOf(1L, 2L)), // 서울시청 근처
-        Triple(37.5640, 126.9750, listOf(3L)), // 을지로 근처
-        Triple(37.5660, 126.9820, listOf(4L, 5L, 6L)) // 종로 근처
+        Triple(37.5665, 126.9780, listOf(1L, 2L)),
+        Triple(37.5640, 126.9750, listOf(3L)),
+        Triple(37.5660, 126.9820, listOf(4L, 5L, 6L, 1L, 2L))
     )
-    
+
     sampleMarkers.forEachIndexed { index, (lat, lng, contentIds) ->
         val marker = Marker()
         marker.position = LatLng(lat, lng)
         marker.map = map
         marker.captionText = "마커 ${index + 1}"
-        
+
         marker.setOnClickListener {
             mapViewModel.onMarkerClick(
                 contentId = contentIds.first(),

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/theme/Theme.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/theme/Theme.kt
@@ -1,19 +1,10 @@
 package com.shinhan.campung.presentation.ui.theme
 
-import android.app.Activity
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 private val DarkColorScheme = darkColorScheme(
     primary = Purple80,

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/utils/TimeFormatter.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/utils/TimeFormatter.kt
@@ -1,0 +1,21 @@
+package com.shinhan.campung.presentation.utils
+
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object TimeFormatter {
+    fun formatRelativeTime(dateTime: LocalDateTime): String {
+        val now = LocalDateTime.now()
+        val duration = Duration.between(dateTime, now)
+        
+        return when {
+            duration.toMinutes() < 1 -> "방금 전"
+            duration.toMinutes() < 60 -> "${duration.toMinutes()}분 전"
+            duration.toHours() < 24 -> "${duration.toHours()}시간 전"
+            duration.toDays() == 1L -> "어제"
+            duration.toDays() < 7 -> "${duration.toDays()}일 전"
+            else -> dateTime.format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"))
+        }
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
@@ -1,0 +1,69 @@
+package com.shinhan.campung.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.shinhan.campung.data.model.MapContent
+import com.shinhan.campung.data.repository.MapContentRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MapViewModel @Inject constructor(
+    private val mapContentRepository: MapContentRepository
+) : ViewModel() {
+    
+    // UI States
+    private val _bottomSheetContents = MutableStateFlow<List<MapContent>>(emptyList())
+    val bottomSheetContents: StateFlow<List<MapContent>> = _bottomSheetContents.asStateFlow()
+    
+    private val _selectedMarkerId = MutableStateFlow<Long?>(null)
+    val selectedMarkerId: StateFlow<Long?> = _selectedMarkerId.asStateFlow()
+    
+    private val _isBottomSheetExpanded = MutableStateFlow(false)
+    val isBottomSheetExpanded: StateFlow<Boolean> = _isBottomSheetExpanded.asStateFlow()
+    
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+    
+    // 마커 클릭 처리
+    fun onMarkerClick(contentId: Long, associatedContentIds: List<Long>) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _selectedMarkerId.value = contentId
+            
+            mapContentRepository.getContentsByIds(associatedContentIds)
+                .onSuccess { contents ->
+                    _bottomSheetContents.value = contents
+                    _isBottomSheetExpanded.value = true
+                }
+                .onFailure { 
+                    _bottomSheetContents.value = emptyList()
+                }
+            
+            _isLoading.value = false
+        }
+    }
+    
+    // 지도 이동시 바텀시트 축소
+    fun onMapMove() {
+        if (_isBottomSheetExpanded.value) {
+            _isBottomSheetExpanded.value = false
+        }
+    }
+    
+    // 바텀시트 상태 변경
+    fun onBottomSheetStateChange(expanded: Boolean) {
+        _isBottomSheetExpanded.value = expanded
+    }
+    
+    // 바텀시트 닫기
+    fun clearSelection() {
+        _selectedMarkerId.value = null
+        _bottomSheetContents.value = emptyList()
+        _isBottomSheetExpanded.value = false
+    }
+}

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
@@ -29,19 +29,23 @@ class MapViewModel @Inject constructor(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
     
-    // 마커 클릭 처리
+    // 마커 클릭 처리 (자연스러운 바텀시트)
     fun onMarkerClick(contentId: Long, associatedContentIds: List<Long>) {
+        _selectedMarkerId.value = contentId
+        _isLoading.value = true
+        // 로딩 상태에서 즉시 바텀시트 확장 (로딩 UI 표시)
+        _isBottomSheetExpanded.value = true
+        
+        // 데이터 로드
         viewModelScope.launch {
-            _isLoading.value = true
-            _selectedMarkerId.value = contentId
-            
             mapContentRepository.getContentsByIds(associatedContentIds)
                 .onSuccess { contents ->
                     _bottomSheetContents.value = contents
-                    _isBottomSheetExpanded.value = true
+                    // 컨텐츠가 준비되더라도 이미 확장된 상태 유지
                 }
                 .onFailure { 
                     _bottomSheetContents.value = emptyList()
+                    _isBottomSheetExpanded.value = false  // 실패시만 바텀시트 닫기
                 }
             
             _isLoading.value = false

--- a/android/campung/app/src/main/res/drawable/ic_comment.xml
+++ b/android/campung/app/src/main/res/drawable/ic_comment.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M21.99,4c0,-1.1 -0.89,-2 -2,-2H4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h14l4,4 -0.01,-18zM18,14H6v-2h12v2zM18,11H6V9h12v2zM18,8H6V6h12v2z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_free.xml
+++ b/android/campung/app/src/main/res/drawable/ic_free.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M20,6h-2.18c0.11,-0.31 0.18,-0.65 0.18,-1a2.996,2.996 0,0 0,-5.5 -1.65l-0.5,0.67l-0.5,-0.68C10.96,2.54 10.05,2 9,2 7.34,2 6,3.34 6,5c0,0.35 0.07,0.69 0.18,1L4,6c-1.11,0 -1.99,0.89 -1.99,2L2,19c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2L22,8c0,-1.11 -0.89,-2 -2,-2zM15,9c0,1.1 -0.9,2 -2,2s-2,-0.9 -2,-2 0.9,-2 2,-2 2,0.9 2,2zM9,20L7,20v-2h2v2zM9,17L7,17v-2h2v2zM9,14L7,14v-2h2v2zM17,20h-2v-2h2v2zM17,17h-2v-2h2v2zM17,14h-2v-2h2v2z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_heart.xml
+++ b/android/campung/app/src/main/res/drawable/ic_heart.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,0.99 3.57,2.36h1.87C13.46,5.99 14.96,5 16.5,5c2,0 3.5,1.5 3.5,3.5 0,2.89 -3.14,5.74 -7.9,10.05z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_hot.xml
+++ b/android/campung/app/src/main/res/drawable/ic_hot.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M13.5,0.67s0.74,2.65 0.74,4.8c0,2.06 -1.35,3.73 -3.41,3.73 -2.07,0 -3.63,-1.67 -3.63,-3.73l0.03,-0.36C5.21,7.51 4,10.62 4,14c0,4.42 3.58,8 8,8s8,-3.58 8,-8C20,8.61 17.41,3.8 13.5,0.67zM11.71,19c-1.78,0 -3.22,-1.4 -3.22,-3.14 0,-1.62 1.05,-2.76 2.81,-3.12 1.77,-0.36 3.6,-1.21 4.62,-2.58 0.39,1.29 0.59,2.65 0.59,4.04 0,2.65 -2.15,4.8 -4.8,4.8z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_info.xml
+++ b/android/campung/app/src/main/res/drawable/ic_info.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_market.xml
+++ b/android/campung/app/src/main/res/drawable/ic_market.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,18c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM1,2v2h2l3.6,7.59 -1.35,2.45c-0.16,0.28 -0.25,0.61 -0.25,0.96 0,1.1 0.9,2 2,2h12v-2L7.42,15c-0.14,0 -0.25,-0.11 -0.25,-0.25l0.03,-0.12L8.1,13h7.45c0.75,0 1.41,-0.41 1.75,-1.03L21.7,4H5.21l-0.94,-2L1,2zM17,18c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/android/campung/app/src/main/res/drawable/ic_promotion.xml
+++ b/android/campung/app/src/main/res/drawable/ic_promotion.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M18,4l2,4h-3l-2,-4h-2l2,4h-3l-2,-4H8l2,4H7L5,4H4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6c0,-1.1 -0.9,-2 -2,-2H18z"/>
+</vector>


### PR DESCRIPTION
# 개선 사항 요약

## 1) 커스텀 바텀시트

* 로딩/컨텐츠 상태에 따라 동적 높이 계산
* `Animatable` 기반 부드러운 드래그 애니메이션
* 드래그 핸들 크기 확대: **20dp → 30dp**
* 핸들 영역만 드래그 가능하도록 제스처 제한

## 2) LocationButton 연동

* 바텀시트 이동에 맞춰 **실시간 위치 보정**
* 드래그 핸들과 **겹치지 않도록 기본 오프셋** 적용

## 3) UI/UX 정교화

* 바텀시트 **불투명 배경** 처리로 지도 비침 방지
* `WindowInsets`로 **상태바/네비게이션바 반영**한 정확한 위치 계산
* `MapContentItem` 레이아웃 밸런스 조정

## 4) 컨텐츠 아이템

* **정사각형 96×96dp** 이미지 적용, 세로 중앙 정렬
* 제목 **1줄**, 내용 **2줄** 제한 + 말줄임 처리
* 작성자 정보 ↔ 좋아요/댓글 **양끝 정렬**

---

## 🔧 기술 변경

* `BottomSheetScaffold` → **커스텀 바텀시트**로 전환
* **`Animatable`** 도입(자연스러운 이동/감속)
* **`WindowInsets`** 활용해 시스템 바 높이 정확 계산
* **로딩 상태별 `LaunchedEffect` 분리**로 상태 전이 안정화

---

## 📱 사용자 경험 효과

* 마커 클릭 시 **즉시 반응** + 로딩 표시
* **직관적 드래그**(핸들 중심)로 오동작 최소화
* LocationButton이 시트와 **자연스럽게 동기화**
* 컨텐츠 개수와 무관하게 **적절한 시트 크기** 유지
