### PR TITLE
feat: 댓글/답글 기능 완전 구현 및 UI/UX 개선

### DIFF
--- a/android/campung/.claude/settings.local.json
+++ b/android/campung/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Read(C:\\SSAFY\\shinhan\\dev\\campung\\android\\campung\\app\\src\\main\\java\\com\\shinhan\\campung\\presentation\\ui\\screens/**)",
       "Read(C:\\SSAFY\\shinhan\\dev\\campung\\android\\campung\\app\\src\\main\\java\\com\\shinhan\\campung\\presentation\\ui\\map/**)",
       "Bash(git add:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(git log:*)"
     ],
     "deny": [],
     "ask": []

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/model/MapContent.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/model/MapContent.kt
@@ -39,12 +39,30 @@ data class MapContent(
     
     private fun parseDateTime(dateStr: String): LocalDateTime {
         return try {
-            // Z가 없는 경우 UTC로 간주하고 Z 추가
-            val normalizedDateStr = if (dateStr.endsWith("Z")) dateStr else "${dateStr}Z"
-            // UTC 시간을 한국 시간으로 변환
-            val zonedDateTime = ZonedDateTime.parse(normalizedDateStr)
-            zonedDateTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+            android.util.Log.d("MapContent", "Original API dateStr: $dateStr")
+            
+            // Z가 붙어있어도 실제로는 한국시간일 가능성이 높음
+            // 일단 Z를 제거하고 한국시간으로 직접 파싱
+            val cleanDateStr = dateStr.removeSuffix("Z")
+            android.util.Log.d("MapContent", "Cleaned dateStr: $cleanDateStr")
+            
+            // 마이크로초가 포함된 경우 밀리초로 잘라내기 (6자리 → 3자리)
+            val truncatedStr = if (cleanDateStr.contains(".") && cleanDateStr.substringAfter(".").length > 3) {
+                val beforeDot = cleanDateStr.substringBefore(".")
+                val afterDot = cleanDateStr.substringAfter(".")
+                val truncatedMicros = afterDot.take(3)
+                "$beforeDot.$truncatedMicros"
+            } else {
+                cleanDateStr
+            }
+            android.util.Log.d("MapContent", "Final dateStr for parsing: $truncatedStr")
+            
+            val result = LocalDateTime.parse(truncatedStr)
+            android.util.Log.d("MapContent", "Parsed LocalDateTime: $result")
+            
+            result
         } catch (e: Exception) {
+            android.util.Log.e("MapContent", "Error parsing dateTime: $dateStr", e)
             // 한국 현재 시간으로 fallback
             ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()
         }
@@ -129,7 +147,31 @@ data class Comment(
     val createdAt: String,
     val replies: List<Reply>?,
     val replyCount: Int
-)
+) {
+    val createdAtDateTime: LocalDateTime get() = parseDateTime(createdAt)
+    
+    private fun parseDateTime(dateStr: String): LocalDateTime {
+        return try {
+            // Z가 붙어있어도 실제로는 한국시간으로 직접 파싱
+            val cleanDateStr = dateStr.removeSuffix("Z")
+            
+            // 마이크로초가 포함된 경우 밀리초로 잘라내기 (6자리 → 3자리)
+            val truncatedStr = if (cleanDateStr.contains(".") && cleanDateStr.substringAfter(".").length > 3) {
+                val beforeDot = cleanDateStr.substringBefore(".")
+                val afterDot = cleanDateStr.substringAfter(".")
+                val truncatedMicros = afterDot.take(3)
+                "$beforeDot.$truncatedMicros"
+            } else {
+                cleanDateStr
+            }
+            
+            LocalDateTime.parse(truncatedStr)
+        } catch (e: Exception) {
+            // 한국 현재 시간으로 fallback
+            ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+        }
+    }
+}
 
 data class Reply(
     val replyId: Long,
@@ -138,7 +180,31 @@ data class Reply(
     val body: String,
     val mediaFiles: List<MediaFile>?,
     val createdAt: String
-)
+) {
+    val createdAtDateTime: LocalDateTime get() = parseDateTime(createdAt)
+    
+    private fun parseDateTime(dateStr: String): LocalDateTime {
+        return try {
+            // Z가 붙어있어도 실제로는 한국시간으로 직접 파싱
+            val cleanDateStr = dateStr.removeSuffix("Z")
+            
+            // 마이크로초가 포함된 경우 밀리초로 잘라내기 (6자리 → 3자리)
+            val truncatedStr = if (cleanDateStr.contains(".") && cleanDateStr.substringAfter(".").length > 3) {
+                val beforeDot = cleanDateStr.substringBefore(".")
+                val afterDot = cleanDateStr.substringAfter(".")
+                val truncatedMicros = afterDot.take(3)
+                "$beforeDot.$truncatedMicros"
+            } else {
+                cleanDateStr
+            }
+            
+            LocalDateTime.parse(truncatedStr)
+        } catch (e: Exception) {
+            // 한국 현재 시간으로 fallback
+            ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()
+        }
+    }
+}
 
 data class LikeResponse(
     val isLiked: Boolean,

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/ContentsApiService.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/ContentsApiService.kt
@@ -35,12 +35,14 @@ interface ContentsApiService {
         @Path("contentId") contentId: Long
     ): Response<CommentListResponse>
 
-    // 댓글 작성
+    // 댓글 작성 - multipart/form-data (최신 스웨거 스펙)
+    @Multipart
     @POST("/api/contents/{contentId}/comments")
     suspend fun postComment(
         @Path("contentId") contentId: Long,
-        @Query("body") body: String,
-        @Query("isAnonymous") isAnonymous: Boolean
+        @Part("body") body: RequestBody,
+        @Part("isAnonymous") isAnonymous: RequestBody,
+        @Part("parentCommentId") parentCommentId: RequestBody
     ): Response<CommentResponse>
 
     @Multipart
@@ -57,7 +59,7 @@ interface ContentsApiService {
         @Part files: List<MultipartBody.Part>?,    // ✅ 파일은 Part로!
     ): ContentCreateResponse
 
-    // 대댓글 작성
+    // 대댓글 작성 - multipart/form-data (최신 스웨거 스펙)
     @Multipart
     @POST("/api/contents/{contentId}/comments/{commentId}/replies")
     suspend fun postReply(

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/remote/dto/CommentRequest.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/remote/dto/CommentRequest.kt
@@ -2,8 +2,13 @@ package com.shinhan.campung.data.remote.dto
 
 data class CommentRequest(
     val body: String,
+    val isAnonymous: Boolean
+)
+
+data class ReplyRequest(
+    val body: String,
     val isAnonymous: Boolean,
-    val parentCommentId: Long? = null
+    val parentCommentId: Long
 )
 
 data class CommentResponse(

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/repository/ContentRepository.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/repository/ContentRepository.kt
@@ -92,8 +92,9 @@ class ContentRepositoryImpl @Inject constructor(
         try {
             val response = contentApiService.postComment(
                 contentId = contentId,
-                body = body,
-                isAnonymous = isAnonymous
+                body = body.toRequestBody(),
+                isAnonymous = isAnonymous.toString().toRequestBody(),
+                parentCommentId = "".toRequestBody() // 일반 댓글은 빈 문자열
             )
             
             if (!response.isSuccessful || response.body()?.success != true) {

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/comment/CommentItem.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/comment/CommentItem.kt
@@ -18,9 +18,7 @@ import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.shinhan.campung.data.model.Comment
 import com.shinhan.campung.presentation.ui.theme.CampusSecondary
-import java.time.LocalDateTime
-import java.time.ZonedDateTime
-import java.time.ZoneId
+import com.shinhan.campung.presentation.utils.TimeFormatter
 
 @Composable
 fun CommentItem(
@@ -66,7 +64,7 @@ fun CommentItem(
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text(
-                        text = formatTimeAgo(parseDateTime(comment.createdAt)),
+                        text = TimeFormatter.formatRelativeTime(comment.createdAtDateTime),
                         fontSize = 12.sp,
                         color = Color(0xFF999999)
                     )
@@ -123,7 +121,7 @@ fun CommentItem(
                         )
                         Spacer(modifier = Modifier.width(8.dp))
                         Text(
-                            text = formatTimeAgo(parseDateTime(reply.createdAt)),
+                            text = TimeFormatter.formatRelativeTime(reply.createdAtDateTime),
                             fontSize = 12.sp,
                             color = Color(0xFF999999)
                         )
@@ -140,33 +138,5 @@ fun CommentItem(
                 }
             }
         }
-    }
-}
-
-private fun formatTimeAgo(dateTime: LocalDateTime): String {
-    // 한국 시간으로 변환
-    val koreaZone = ZoneId.of("Asia/Seoul")
-    val now = ZonedDateTime.now(koreaZone).toLocalDateTime()
-    val minutes = java.time.temporal.ChronoUnit.MINUTES.between(dateTime, now)
-    
-    return when {
-        minutes < 1 -> "방금 전"
-        minutes < 60 -> "${minutes}분 전"
-        minutes < 1440 -> "${minutes / 60}시간 전"
-        minutes < 10080 -> "${minutes / 1440}일 전"
-        else -> dateTime.format(java.time.format.DateTimeFormatter.ofPattern("MM/dd"))
-    }
-}
-
-private fun parseDateTime(dateStr: String): LocalDateTime {
-    return try {
-        // Z가 없는 경우 UTC로 간주하고 Z 추가
-        val normalizedDateStr = if (dateStr.endsWith("Z")) dateStr else "${dateStr}Z"
-        // UTC 시간을 한국 시간으로 변환
-        val zonedDateTime = ZonedDateTime.parse(normalizedDateStr)
-        zonedDateTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
-    } catch (e: Exception) {
-        // 한국 현재 시간으로 fallback
-        ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime()
     }
 }

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/content/AuthorSection.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/content/AuthorSection.kt
@@ -16,10 +16,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.shinhan.campung.data.model.Author
+import com.shinhan.campung.presentation.utils.TimeFormatter
 import java.time.LocalDateTime
-import java.time.ZonedDateTime
-import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 
 @Composable
 fun AuthorSection(
@@ -53,25 +51,10 @@ fun AuthorSection(
                 color = Color.Black
             )
             Text(
-                text = formatTimeAgo(createdAt),
+                text = TimeFormatter.formatRelativeTime(createdAt),
                 fontSize = 14.sp,
                 color = Color(0xFF666666)
             )
         }
-    }
-}
-
-private fun formatTimeAgo(dateTime: LocalDateTime): String {
-    // 한국 시간으로 변환
-    val koreaZone = ZoneId.of("Asia/Seoul")
-    val now = ZonedDateTime.now(koreaZone).toLocalDateTime()
-    val minutes = ChronoUnit.MINUTES.between(dateTime, now)
-    
-    return when {
-        minutes < 1 -> "방금 전"
-        minutes < 60 -> "${minutes}분 전"
-        minutes < 1440 -> "${minutes / 60}시간 전"
-        minutes < 10080 -> "${minutes / 1440}일 전"
-        else -> dateTime.format(java.time.format.DateTimeFormatter.ofPattern("MM/dd"))
     }
 }

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/content/MediaPagerSection.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/components/content/MediaPagerSection.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.VolumeOff
 import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.*
@@ -22,6 +23,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
@@ -37,6 +40,8 @@ fun MediaPagerSection(
     val pagerState = rememberPagerState(
         pageCount = { mediaFiles.size }
     )
+    var showFullScreenImage by remember { mutableStateOf(false) }
+    var fullScreenImageUrl by remember { mutableStateOf("") }
 
     Box(
         modifier = modifier
@@ -54,7 +59,12 @@ fun MediaPagerSection(
                     AsyncImage(
                         model = mediaFile.fileUrl,
                         contentDescription = "이미지",
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable {
+                                fullScreenImageUrl = mediaFile.fileUrl
+                                showFullScreenImage = true
+                            },
                         contentScale = ContentScale.Crop
                     )
                 }
@@ -82,6 +92,60 @@ fun MediaPagerSection(
                 color = Color.White,
                 fontSize = 12.sp
             )
+        }
+    }
+    
+    // 전체화면 이미지 다이얼로그
+    if (showFullScreenImage) {
+        FullScreenImageDialog(
+            imageUrl = fullScreenImageUrl,
+            onDismiss = { showFullScreenImage = false }
+        )
+    }
+}
+
+@Composable
+private fun FullScreenImageDialog(
+    imageUrl: String,
+    onDismiss: () -> Unit
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .clickable { onDismiss() }
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = "전체화면 이미지",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit
+            )
+            
+            // 닫기 버튼
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(16.dp)
+                    .background(
+                        Color.Black.copy(alpha = 0.5f),
+                        CircleShape
+                    )
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "닫기",
+                    tint = Color.White
+                )
+            }
         }
     }
 }
@@ -131,7 +195,7 @@ private fun VideoPlayerView(
                 PlayerView(context).apply {
                     player = exoPlayer
                     useController = false
-                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_ZOOM
+                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
                 }
             },
             modifier = Modifier.fillMaxSize()

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/contentdetail/ContentDetailScreen.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/contentdetail/ContentDetailScreen.kt
@@ -165,17 +165,44 @@ private fun ContentDetailScreenContent(
                         createdAt = content.createdAtDateTime
                     )
                 }
+                
+                // 작성자 정보 구분선
+                item {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                        thickness = 0.5.dp,
+                        color = Color(0xFFE0E0E0)
+                    )
+                }
 
                 // 미디어 파일 (이미지/비디오)
                 if (!content.mediaFiles.isNullOrEmpty()) {
                     item {
                         MediaPagerSection(mediaFiles = content.mediaFiles)
                     }
+                    
+                    // 미디어 구분선
+                    item {
+                        HorizontalDivider(
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            thickness = 0.5.dp,
+                            color = Color(0xFFE0E0E0)
+                        )
+                    }
                 }
 
                 // 컨텐츠 텍스트
                 item {
                     ContentTextSection(content = content.body)
+                }
+                
+                // 컨텐츠 텍스트 구분선
+                item {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                        thickness = 0.5.dp,
+                        color = Color(0xFFE0E0E0)
+                    )
                 }
 
                 // 좋아요/댓글 수 바
@@ -187,14 +214,63 @@ private fun ContentDetailScreenContent(
                         onLikeClick = onLikeClick
                     )
                 }
-
-                // 댓글 목록
-                items(uiState.comments) { comment ->
-                    CommentItem(
-                        comment = comment,
-                        onReplyClick = onReplyClick,
-                        isSelected = comment.commentId == uiState.selectedCommentId
+                
+                // 댓글 영역 구분선
+                item {
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                        thickness = 1.dp,
+                        color = Color(0xFFE0E0E0)
                     )
+                }
+
+                // 댓글 목록 또는 빈 상태
+                if (uiState.comments.isEmpty() && !uiState.isCommentLoading) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(32.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "첫 번째 댓글을 남겨보세요!",
+                                    fontSize = 16.sp,
+                                    color = Color(0xFF999999),
+                                    fontWeight = FontWeight.Medium
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = "이 게시물에 대한 생각을 공유해 주세요",
+                                    fontSize = 14.sp,
+                                    color = Color(0xFFBBBBBB)
+                                )
+                            }
+                        }
+                    }
+                } else {
+                    // 댓글 목록
+                    items(uiState.comments.size) { index ->
+                        val comment = uiState.comments[index]
+                        
+                        CommentItem(
+                            comment = comment,
+                            onReplyClick = onReplyClick,
+                            isSelected = comment.commentId == uiState.selectedCommentId
+                        )
+                        
+                        // 댓글 사이 구분선 (마지막 댓글은 제외)
+                        if (index < uiState.comments.size - 1) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                                thickness = 0.5.dp,
+                                color = Color(0xFFF0F0F0)
+                            )
+                        }
+                    }
                 }
 
                 // 댓글 로딩 표시

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/utils/TimeFormatter.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/utils/TimeFormatter.kt
@@ -1,13 +1,37 @@
 package com.shinhan.campung.presentation.utils
 
+import android.util.Log
 import java.time.Duration
 import java.time.LocalDateTime
+import java.time.ZonedDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 object TimeFormatter {
     fun formatRelativeTime(dateTime: LocalDateTime): String {
-        val now = LocalDateTime.now()
-        val duration = Duration.between(dateTime, now)
+        // 한국 시간대 설정
+        val koreaZone = ZoneId.of("Asia/Seoul")
+        
+        // dateTime을 한국 시간대의 ZonedDateTime으로 변환 (이미 한국 시간으로 파싱됨)
+        val zonedDateTime = dateTime.atZone(koreaZone)
+        
+        // 현재 한국 시간
+        val now = ZonedDateTime.now(koreaZone)
+        
+        // 정확한 duration 계산
+        val duration = Duration.between(zonedDateTime, now)
+        
+        // 디버깅용 로그
+        Log.d("TimeFormatter", "Original dateTime: $dateTime")
+        Log.d("TimeFormatter", "ZonedDateTime: $zonedDateTime")
+        Log.d("TimeFormatter", "Current time: $now")
+        Log.d("TimeFormatter", "Duration minutes: ${duration.toMinutes()}")
+        
+        // 미래 시간인 경우 (duration이 음수)
+        if (duration.isNegative) {
+            Log.d("TimeFormatter", "Duration is negative (${duration.toMinutes()} min), returning '방금 전'")
+            return "방금 전"
+        }
         
         return when {
             duration.toMinutes() < 1 -> "방금 전"


### PR DESCRIPTION
API 통합:
- ContentsApiService: multipart/form-data 방식으로 댓글/답글 API 변경
- ContentRepository: parentCommentId 처리 로직 수정 (빈 문자열로 설정)
- Authorization 헤더 중복 제거 (Interceptor에서 자동 처리)

시간 표시 개선:
- TimeFormatter: timezone 변환 로직 수정으로 "방금 전" 오류 해결
- MapContent: parseDateTime 함수에서 Z suffix 제거 후 한국시간으로 파싱
- Comment/Reply 모델: 동일한 시간 파싱 로직 적용

UI 컴포넌트 개선:
- MediaPagerSection: 클릭 시 전체화면 이미지 뷰어 추가
- 정사각형 비율 미디어 표시 및 영상 RESIZE_MODE_FIT 적용
- ContentDetailScreen: 섹션별 구분선 추가로 가독성 향상
- 댓글 없을 때 안내 메시지 표시

중복 코드 제거:
- CommentItem, AuthorSection: 개별 formatTimeAgo 함수 제거
- 통일된 TimeFormatter.formatRelativeTime 사용