### PR TITLE
feat: 지도 화면 기본 상태에서 핫 게시글 표시 기능 구현

### DIFF
--- a/android/campung/app/src/main/java/com/shinhan/campung/data/model/ContentResponse.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/model/ContentResponse.kt
@@ -8,6 +8,12 @@ data class ContentResponse(
     val data: ContentData
 )
 
+data class HotContentsResponse(
+    val success: Boolean,
+    val message: String,
+    val data: List<ContentData>
+)
+
 data class ContentData(
     val contentId: Long,
     val userId: String,

--- a/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/ContentsApiService.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/data/remote/api/ContentsApiService.kt
@@ -5,6 +5,7 @@ import okhttp3.MultipartBody
 import com.shinhan.campung.data.remote.dto.CommentListResponse
 import com.shinhan.campung.data.remote.dto.CommentResponse
 import com.shinhan.campung.data.remote.dto.LikeResponse
+import com.shinhan.campung.data.model.HotContentsResponse
 import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.*
@@ -81,4 +82,8 @@ interface ContentsApiService {
     suspend fun deleteContent(
         @Path("contentId") contentId: Long
     ): Response<Unit>
+    
+    // 핫 게시글 조회
+    @GET("/api/contents/hot")
+    suspend fun getHotContents(): Response<HotContentsResponse>
 }

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/ui/screens/FullMapScreen.kt
@@ -444,7 +444,11 @@ fun FullMapScreen(
             map.locationOverlay.isVisible = true
             map.locationOverlay.position = pos
 
-            // 초기 로드 - 강제로 데이터 로드하여 확실히 마커 표시
+            // 초기 로드 - 핫 콘텐츠를 먼저 로드
+            Log.d("FullMapScreen", "🔥 초기 진입 - 핫 콘텐츠 로드")
+            mapViewModel.loadHotContents()
+            
+            // 마커 데이터도 로드 (백그라운드)
             naverMapRef?.let { map ->
                 val radius = com.shinhan.campung.presentation.ui.map.MapBoundsCalculator.calculateVisibleRadius(map)
                 Log.d("FullMapScreen", "🎯 초기 위치 기반 마커 로드: (${pos.latitude}, ${pos.longitude}), 반경: ${radius}m")

--- a/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/presentation/viewmodel/MapViewModel.kt
@@ -420,10 +420,39 @@ class MapViewModel @Inject constructor(
     fun clearSelectedMarker() {
         selectedMarker = null
         _selectedMarkerId.value = null
-        _bottomSheetContents.value = emptyList()
-        _isBottomSheetExpanded.value = false
         _isLoading.value = false
         Log.d(TAG, "마커 선택 해제됨")
+        
+        // 핫 콘텐츠로 복귀
+        loadHotContents()
+    }
+    
+    fun loadHotContents() {
+        Log.d(TAG, "🔥 [FLOW] loadHotContents 시작 - 핫 게시글 로드")
+        _isLoading.value = true
+        
+        viewModelScope.launch {
+            try {
+                mapContentRepository.getHotContents()
+                    .onSuccess { hotContents ->
+                        Log.d(TAG, "✅ [FLOW] 핫 콘텐츠 로드 성공 - ${hotContents.size}개")
+                        _bottomSheetContents.value = hotContents
+                        _isBottomSheetExpanded.value = true // 핫 콘텐츠 표시 시 확장
+                        _isLoading.value = false
+                    }
+                    .onFailure { e ->
+                        Log.e(TAG, "❌ [FLOW] 핫 콘텐츠 로드 실패", e)
+                        _bottomSheetContents.value = emptyList()
+                        _isBottomSheetExpanded.value = false
+                        _isLoading.value = false
+                    }
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ [FLOW] 핫 콘텐츠 로드 중 예외", e)
+                _bottomSheetContents.value = emptyList()
+                _isBottomSheetExpanded.value = false
+                _isLoading.value = false
+            }
+        }
     }
 
     fun isMarkerSelected(mapContent: MapContent): Boolean {
@@ -464,8 +493,10 @@ class MapViewModel @Inject constructor(
     // 바텀시트 닫기
     fun clearSelection() {
         _selectedMarkerId.value = null
-        _bottomSheetContents.value = emptyList()
         _isBottomSheetExpanded.value = false
+        
+        // 핫 콘텐츠로 복귀
+        loadHotContents()
     }
 
     fun clusteringUpdated() {
@@ -482,12 +513,13 @@ class MapViewModel @Inject constructor(
 
         // 선택된 마커도 클리어
         selectedMarker = null
-        clearSelectedMarker()
+        _selectedMarkerId.value = null
 
         // lastRequestParams 초기화로 새로운 요청 허용
         lastRequestParams = null
-
-        // 날짜가 변경되면 다시 로드
+        
+        // 핫 콘텐츠로 복귀
+        loadHotContents()
     }
     
     fun selectPreviousDate() {
@@ -526,7 +558,7 @@ class MapViewModel @Inject constructor(
 
         // 선택된 마커도 클리어
         selectedMarker = null
-        clearSelectedMarker()
+        _selectedMarkerId.value = null
 
         // lastRequestParams 초기화로 새로운 요청 허용
         lastRequestParams = null
@@ -534,6 +566,11 @@ class MapViewModel @Inject constructor(
         // 필터가 변경되면 다시 로드
         lastRequestLocation?.let { (lat, lng) ->
             loadMapContents(lat, lng, force = true)
+        }
+        
+        // 마커 데이터가 없을 때 핫 콘텐츠로 복귀
+        if (mapContents.isEmpty()) {
+            loadHotContents()
         }
     }
 
@@ -547,7 +584,7 @@ class MapViewModel @Inject constructor(
 
         // 선택된 마커도 클리어
         selectedMarker = null
-        clearSelectedMarker()
+        _selectedMarkerId.value = null
 
         // lastRequestParams 초기화로 새로운 요청 허용
         lastRequestParams = null
@@ -555,6 +592,11 @@ class MapViewModel @Inject constructor(
         // postType 변경 시 다시 로드
         lastRequestLocation?.let { (lat, lng) ->
             loadMapContents(lat, lng, force = true)
+        }
+        
+        // 마커 데이터가 없을 때 핫 콘텐츠로 복귀
+        if (mapContents.isEmpty()) {
+            loadHotContents()
         }
     }
 


### PR DESCRIPTION
- 마커 선택 없이 지도 진입 시 핫 게시글 5개 자동 표시
- HotContentsResponse 데이터 모델 추가
- ContentsApiService에 핫 게시글 조회 API 엔드포인트 추가
- MapContentRepository에 핫 게시글 조회 로직 구현
- MapViewModel에 loadHotContents() 함수 추가
- FullMapScreen 초기 로드 시 핫 게시글 자동 로드
- API 응답 null 처리 및 에러 핸들링 강화
- 상세한 로깅으로 데이터 플로우 추적 가능