### PR TITLE
fix: AppNav 로그인 상태에 따른 라우팅 로직 수정

### DIFF
--- a/android/campung/app/src/main/java/com/shinhan/campung/navigation/AppNav.kt
+++ b/android/campung/app/src/main/java/com/shinhan/campung/navigation/AppNav.kt
@@ -55,11 +55,20 @@ fun AppNav(
         onNavControllerReady(navController)
     }
 
-    // 1) 상태 수집: 로그인 상태
+    // 1) 로딩 상태 관리
+    var isInitialLoading by remember { mutableStateOf(true) }
     val userId by authDataStore.userIdFlow.collectAsState(initial = null)
-
-    // 2) userId가 아직 로드되지 않았으면 로딩 화면 표시
-    if (userId == null) {
+    
+    // 2) 첫 번째 값이 도착하면 (null이든 실제값이든) 로딩 완료
+    LaunchedEffect(Unit) {
+        val firstValue = authDataStore.userIdFlow.first()
+        isInitialLoading = false
+        android.util.Log.d("AppNav", "DataStore 로딩 완료 - userId: '$firstValue'")
+    }
+    
+    // 3) 초기 로딩 중이면 로딩 화면 표시
+    if (isInitialLoading) {
+        android.util.Log.d("AppNav", "초기 로딩 중...")
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
@@ -69,8 +78,13 @@ fun AppNav(
         return
     }
 
-    // 3) userId가 로드된 후 적절한 화면 결정
-    val startRoute = if (userId?.isBlank() != false) Route.LOGIN else Route.HOME
+    // 4) 로딩 완료 후 적절한 화면 결정
+    val startRoute = if (userId.isNullOrBlank()) Route.LOGIN else Route.HOME
+    
+    // 디버깅 로그
+    LaunchedEffect(startRoute) {
+        android.util.Log.d("AppNav", "라우팅 결정: userId = '$userId', startRoute = '$startRoute'")
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         // 항상 깔리는 기본 배경 (검은 잔상 방지)


### PR DESCRIPTION
- DataStore 로딩 완료 후에만 라우팅 결정하도록 수정
- 로그인 정보가 있으면 바로 홈 화면으로, 없으면 바로 로그인 화면으로 이동
- 무한 로딩 문제 해결 및 중간 화면 전환 제거